### PR TITLE
Fix HTTP/2 compatibility with strict servers like Google

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'packages/**'
       - '.github/workflows/ci.yml'
+  # Allow manual trigger for e2e tests
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -75,3 +78,27 @@ jobs:
 
       - name: Run linting
         run: make lint
+
+  # E2E tests run on release branches to catch issues before release
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    # Run on release/* branches, or when manually triggered
+    if: startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: e2e
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Run E2E tests
+        run: make test-e2e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orb-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "async-compression",

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo ""
 	@echo "Test Commands:"
 	@echo "  make test               - Run all tests"
+	@echo "  make test-e2e           - Run e2e tests (requires internet)"
 	@echo "  make coverage           - Generate HTML coverage report"
 	@echo ""
 	@echo "Quality Commands:"
@@ -36,6 +37,9 @@ release:
 
 test:
 	cargo test
+
+test-e2e:
+	cargo test --test e2e -- --ignored
 
 coverage:
 	cargo llvm-cov --html

--- a/packages/orb-cli/Cargo.toml
+++ b/packages/orb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Daniel Walsh <orb@walshy.dev>"]
 description = "🟠 Your powerful HTTP client - A powerful cURL alternative with HTTP/1.1, HTTP/2, and HTTP/3"

--- a/packages/orb-cli/tests/e2e.rs
+++ b/packages/orb-cli/tests/e2e.rs
@@ -1,0 +1,162 @@
+//! End-to-end tests against real internet servers.
+//!
+//! These tests are marked with #[ignore] by default since they require internet access.
+//! Run them with: cargo test --test e2e -- --ignored
+//!
+//! These tests validate that orb works correctly with real-world HTTP/2 servers,
+//! which may have stricter requirements than mock servers (e.g., Google's HTTP/2
+//! implementation is particularly strict about header handling).
+
+use assert_cmd::cargo::*;
+use std::process::Command;
+use test_case::test_case;
+
+/// Helper to run orb and return (success, stdout, stderr)
+fn run_orb(args: &[&str]) -> (bool, String, String) {
+    let output = Command::new(cargo_bin!("orb"))
+        .args(args)
+        .output()
+        .expect("Failed to execute orb");
+
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+// =============================================================================
+// Basic Connectivity Tests (parameterized)
+// =============================================================================
+
+/// Test that sites work with default settings.
+#[test_case("https://www.google.com/"; "google")]
+#[test_case("https://www.cloudflare.com/"; "cloudflare")]
+#[test_case("https://httpbin.org/get"; "httpbin")]
+#[test_case("https://example.com/"; "example")]
+#[test_case("https://test.walshy.dev/"; "personal test site")]
+#[ignore = "requires internet access"]
+fn test_e2e_default(url: &str) {
+    let (success, stdout, stderr) = run_orb(&[url, "-L"]);
+
+    assert!(
+        success,
+        "Request to {} failed.\nstderr: {}\nstdout: {}",
+        url, stderr, stdout
+    );
+}
+
+/// Test HTTP/2 support across sites.
+#[test_case("https://www.google.com/"; "google")]
+#[test_case("https://www.cloudflare.com/"; "cloudflare")]
+#[test_case("https://httpbin.org/get"; "httpbin")]
+#[test_case("https://example.com/"; "example")]
+#[test_case("https://test.walshy.dev/"; "personal test site")]
+#[ignore = "requires internet access"]
+fn test_e2e_http2(url: &str) {
+    let (success, stdout, stderr) = run_orb(&[url, "--http2", "-i", "-L"]);
+
+    assert!(
+        success,
+        "HTTP/2 request to {} failed.\nstderr: {}\nstdout: {}",
+        url, stderr, stdout
+    );
+    assert!(
+        stdout.contains("HTTP/2"),
+        "Expected HTTP/2 response from {}, got:\nstdout: {}",
+        url,
+        stdout
+    );
+}
+
+/// Test HTTP/1.1 fallback across sites.
+#[test_case("https://www.google.com/"; "google")]
+#[test_case("https://www.cloudflare.com/"; "cloudflare")]
+#[test_case("https://example.com/"; "example")]
+#[test_case("https://test.walshy.dev/"; "personal test site")]
+#[ignore = "requires internet access"]
+fn test_e2e_http1_1(url: &str) {
+    let (success, stdout, stderr) = run_orb(&[url, "--http1.1", "-i", "-L"]);
+
+    assert!(
+        success,
+        "HTTP/1.1 request to {} failed.\nstderr: {}\nstdout: {}",
+        url, stderr, stdout
+    );
+    assert!(
+        stdout.contains("HTTP/1.1"),
+        "Expected HTTP/1.1 response from {}, got:\nstdout: {}",
+        url,
+        stdout
+    );
+}
+
+/// Test HTTP/3 (QUIC) support across sites that support it.
+#[test_case("https://www.google.com/"; "google")]
+#[test_case("https://www.cloudflare.com/"; "cloudflare")]
+#[ignore = "requires internet access"]
+fn test_e2e_http3(url: &str) {
+    let (success, stdout, stderr) = run_orb(&[url, "--http3", "-i", "-L", "--max-time", "10"]);
+
+    assert!(
+        success,
+        "HTTP/3 request to {} failed.\nstderr: {}\nstdout: {}",
+        url, stderr, stdout
+    );
+    assert!(
+        stdout.contains("HTTP/3"),
+        "Expected HTTP/3 response from {}, got:\nstdout: {}",
+        url,
+        stdout
+    );
+}
+
+// =============================================================================
+// e2e feature validation
+// =============================================================================
+
+/// Test custom headers are sent correctly.
+#[test]
+#[ignore = "requires internet access"]
+fn test_e2e_test_site_headers() {
+    let (success, stdout, stderr) = run_orb(&[
+        "https://test.walshy.dev/reqinfo",
+        "-H",
+        "X-Test-Header: test-value",
+    ]);
+
+    assert!(
+        success,
+        "test site headers request failed.\nstderr: {}\nstdout: {}",
+        stderr, stdout
+    );
+    assert!(
+        stdout.contains("X-Test-Header") || stdout.contains("x-test-header"),
+        "Custom header not reflected by httpbin, got:\nstdout: {}",
+        stdout
+    );
+}
+
+/// Test POST with body data.
+#[test]
+#[ignore = "requires internet access"]
+fn test_e2e_test_site_post() {
+    let (success, stdout, stderr) = run_orb(&[
+        "https://test.walshy.dev/reqinfo",
+        "-X",
+        "POST",
+        "-d",
+        "test=data",
+    ]);
+
+    assert!(
+        success,
+        "httpbin POST request failed.\nstderr: {}\nstdout: {}",
+        stderr, stdout
+    );
+    assert!(
+        stdout.contains("test=data") || stdout.contains("\"data\""),
+        "POST data not reflected by httpbin, got:\nstdout: {}",
+        stdout
+    );
+}

--- a/packages/orb-cli/tests/fundamental.rs
+++ b/packages/orb-cli/tests/fundamental.rs
@@ -60,9 +60,9 @@ fn test_form_raw() {
     POST / HTTP/1.1
     accept: */*
     user-agent: orb/0.1.0
-    host: 127.0.0.1:<PORT>
     content-type: multipart/form-data; boundary=<BOUNDARY>
     content-length: 131
+    host: 127.0.0.1:<PORT>
 
     --<BOUNDARY>
     Content-Disposition: form-data; name="field1"

--- a/packages/orb-cli/tests/http_protocols.rs
+++ b/packages/orb-cli/tests/http_protocols.rs
@@ -1,0 +1,431 @@
+//! HTTP protocol version tests
+//!
+//! These tests verify correct HTTP/1.1 and HTTP/2 behavior, particularly around
+//! ALPN negotiation and header handling. These tests exist to prevent regressions
+//! like the HTTP/2 failure with Google that was caused by:
+//! 1. ALPN always advertising both protocols regardless of --http1.1/--http2 flags
+//! 2. Explicit Host header conflicting with HTTP/2's :authority pseudo-header
+
+mod testutils;
+
+use assert_cmd::cargo::*;
+use orb_mockhttp::{HttpProtocol, TestServerBuilder};
+use std::process::Command;
+use test_case::test_case;
+
+/// Test that HTTP/2 works correctly when the server supports it.
+/// This is a regression test for the ALPN/Host header issue.
+#[test]
+fn test_http2_with_tls_server() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+    server
+        .on_request("/")
+        .respond_with(200, "Hello from HTTP/2");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--insecure")
+        .arg("-i")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("HTTP/2"),
+        "Expected HTTP/2 response, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Hello from HTTP/2"),
+        "Expected body in response, got: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test that --http1.1 flag forces HTTP/1.1 even when server supports HTTP/2.
+/// This verifies ALPN is correctly configured to only advertise HTTP/1.1.
+#[test]
+fn test_http1_1_flag_forces_http1_1_alpn() {
+    // Server supports both HTTP/1.1 and HTTP/2
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http1, HttpProtocol::Http2])
+        .build();
+    server.on_request("/").respond_with(200, "OK");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--http1.1")
+        .arg("--insecure")
+        .arg("-i")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/1.1 request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("HTTP/1.1"),
+        "Expected HTTP/1.1 response when --http1.1 flag is used, got: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test that --http2 flag forces HTTP/2 when server supports it.
+/// This verifies ALPN is correctly configured to only advertise HTTP/2.
+#[test]
+fn test_http2_flag_forces_http2_alpn() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http1, HttpProtocol::Http2])
+        .build();
+    server.on_request("/").respond_with(200, "OK");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--http2")
+        .arg("--insecure")
+        .arg("-i")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("HTTP/2"),
+        "Expected HTTP/2 response when --http2 flag is used, got: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test that default behavior (no version flag) works with HTTP/2 servers.
+/// Server chooses HTTP/2 via ALPN and the request succeeds.
+#[test]
+fn test_default_uses_alpn_negotiation() {
+    // Server prefers HTTP/2
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2, HttpProtocol::Http1])
+        .build();
+    server.on_request("/").respond_with(200, "ALPN worked");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--insecure")
+        .arg("-i")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Default ALPN negotiation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Server should have chosen HTTP/2 since it's listed first
+    assert!(
+        stdout.contains("HTTP/2"),
+        "Expected HTTP/2 via ALPN negotiation, got: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test HTTP/2 with custom headers to ensure headers are properly handled.
+/// This is a regression test for the Host header conflict issue.
+#[test]
+fn test_http2_with_custom_headers() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+
+    server.on_request_fn("/headers", |req| {
+        // Echo back the headers received
+        let headers: Vec<String> = req
+            .headers()
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("<binary>")))
+            .collect();
+        orb_mockhttp::ResponseBuilder::new()
+            .status(200)
+            .text(headers.join("\n"))
+            .build()
+    });
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/headers"))
+        .arg("--insecure")
+        .arg("-H")
+        .arg("X-Custom-Header: custom-value")
+        .arg("-H")
+        .arg("Accept: application/json")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 with custom headers failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("x-custom-header: custom-value"),
+        "Custom header not received: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("accept: application/json"),
+        "Accept header not received: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test HTTP/2 with POST body to ensure body handling works correctly.
+#[test]
+fn test_http2_with_post_body() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+
+    server.on_request_fn("/echo", |req| {
+        let body = req.text().unwrap_or_default();
+        orb_mockhttp::ResponseBuilder::new()
+            .status(200)
+            .text(format!("Received: {}", body))
+            .build()
+    });
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/echo"))
+        .arg("--insecure")
+        .arg("-X")
+        .arg("POST")
+        .arg("-d")
+        .arg("test data")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 POST failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Received: test data"),
+        "POST body not echoed correctly: {}",
+        stdout
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test verbose output shows correct ALPN negotiation for HTTP/2.
+#[test]
+fn test_http2_verbose_shows_alpn() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+    server.on_request("/").respond_with(200, "OK");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--insecure")
+        .arg("-v")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 verbose request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ALPN: h2"),
+        "Expected ALPN: h2 in verbose output, got: {}",
+        stderr
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test that HTTP/1.1 verbose output does NOT show ALPN h2.
+#[test]
+fn test_http1_1_verbose_no_h2_alpn() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http1, HttpProtocol::Http2])
+        .build();
+    server.on_request("/").respond_with(200, "OK");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/"))
+        .arg("--http1.1")
+        .arg("--insecure")
+        .arg("-v")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/1.1 verbose request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // When --http1.1 is used, ALPN should not negotiate h2
+    assert!(
+        !stderr.contains("ALPN: h2"),
+        "Should not show ALPN: h2 when --http1.1 is used, got: {}",
+        stderr
+    );
+
+    server.assert_requests(1);
+}
+
+/// Test multiple sequential HTTP/2 requests to ensure connection handling is stable.
+#[test]
+fn test_http2_multiple_requests() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+    server.on_request("/1").respond_with(200, "Response 1");
+    server.on_request("/2").respond_with(200, "Response 2");
+    server.on_request("/3").respond_with(200, "Response 3");
+
+    for i in 1..=3 {
+        let output = Command::new(cargo_bin!("orb"))
+            .arg(server.url(&format!("/{}", i)))
+            .arg("--insecure")
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "HTTP/2 request {} failed: {}",
+            i,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(&format!("Response {}", i)),
+            "Expected Response {} in output, got: {}",
+            i,
+            stdout
+        );
+    }
+
+    server.assert_requests(3);
+}
+
+/// Test that HTTP/2 works with redirects.
+#[test]
+fn test_http2_with_redirects() {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http2])
+        .build();
+
+    server
+        .on_request("/redirect")
+        .respond_with_redirect(302, "/final");
+    server
+        .on_request("/final")
+        .respond_with(200, "Final destination");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/redirect"))
+        .arg("--insecure")
+        .arg("-L")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "HTTP/2 redirect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Final destination"),
+        "Expected final response after redirect, got: {}",
+        stdout
+    );
+
+    server.assert_requests(2);
+}
+
+/// Parameterized test for HTTP version flags with different paths.
+#[test_case("--http1.1", "HTTP/1.1"; "http1.1 flag")]
+#[test_case("--http2", "HTTP/2"; "http2 flag")]
+fn test_http_version_flags(flag: &str, expected_version: &str) {
+    let server = TestServerBuilder::new()
+        .with_tls()
+        .with_protocols(&[HttpProtocol::Http1, HttpProtocol::Http2])
+        .build();
+    server.on_request("/test").respond_with(200, "OK");
+
+    let output = Command::new(cargo_bin!("orb"))
+        .arg(server.url("/test"))
+        .arg(flag)
+        .arg("--insecure")
+        .arg("-i")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{} request failed: {}",
+        flag,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(expected_version),
+        "Expected {} in response with {} flag, got: {}",
+        expected_version,
+        flag,
+        stdout
+    );
+
+    server.assert_requests(1);
+}

--- a/packages/orb-client/src/http3_client.rs
+++ b/packages/orb-client/src/http3_client.rs
@@ -148,6 +148,10 @@ async fn send_request_h3(
     let mut req_builder = Request::builder().uri(uri).method(builder.method.clone());
 
     for (key, value) in builder.headers.iter() {
+        // Skip Host header - h3 uses :authority pseudo-header from the URI
+        if key == http::header::HOST {
+            continue;
+        }
         req_builder = req_builder.header(key, value);
     }
 


### PR DESCRIPTION
HTTP/2 requests were failing with Google due to the Host header being passed in addition to the h2 pseudo-header :authority

This did not impact services such as Cloudflare and general nginx servers but did seem to impact Google's servers.

Also, fixed an issue with ALPN ignoring the http version flags.

There are added regression and more coverage tests to catch these bugs as well in the future. Along with new e2e tests which are required on release/* branches. This should help catch issues before a release.

## Testing
<!-- How have you tested these changes? -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

## Checklist
- [x] Code compiles without warnings
- [x] `cargo clippy` passes with no warnings
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## Breaking Changes
N/A

## Related Issues
N/A
