### PR TITLE
fix: don't override user-specified content-type header

### DIFF
--- a/packages/orb-cli/src/request.rs
+++ b/packages/orb-cli/src/request.rs
@@ -36,14 +36,17 @@ pub async fn build_request(builder: RequestBuilder, args: &Args, url: &Url) -> R
     }
 
     let headers = build_headers(args, url);
+    let user_has_content_type = headers.contains_key(CONTENT_TYPE);
     builder = builder.headers(headers);
 
     // Set HTTP version
     builder = set_http_version(builder, args);
 
-    // Build body
+    // Build body — only set auto Content-Type if the user didn't specify one via -H
     let (body, content_type) = build_body(args).await;
-    if let Some(ct) = content_type {
+    if let Some(ct) = content_type
+        && !user_has_content_type
+    {
         builder = builder.header(CONTENT_TYPE, ct);
     }
 

--- a/packages/orb-cli/tests/options.rs
+++ b/packages/orb-cli/tests/options.rs
@@ -172,6 +172,41 @@ fn test_data_invalid(data: &str, expected_error: &str) {
 }
 
 #[test]
+fn test_data_user_content_type_not_overridden() {
+    let server = TestServerBuilder::new().build();
+    server.on_request("/test").respond_with(200, "OK");
+
+    let mut cmd = Command::new(cargo_bin!("orb"));
+    cmd.arg(server.url("/test"))
+        .arg("-X")
+        .arg("POST")
+        .arg("-d")
+        .arg(r#"{"foo": true}"#)
+        .arg("-H")
+        .arg("Content-Type: application/json");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    let request = server.get_raw_request().unwrap();
+    assert!(
+        request
+            .to_lowercase()
+            .contains("content-type: application/json"),
+        "Expected user-specified Content-Type: application/json, got: {}",
+        request
+    );
+    assert!(
+        !request
+            .to_lowercase()
+            .contains("content-type: application/x-www-form-urlencoded"),
+        "User Content-Type should not be overridden by -d default, got: {}",
+        request
+    );
+    server.assert_requests(1);
+}
+
+#[test]
 fn test_json() {
     let server = TestServerBuilder::new().build();
     server.on_request("/test").respond_with(200, "OK");


### PR DESCRIPTION
## Summary
Fixes #28

## Testing
Tests added and all pass as expected

## Checklist
- [x] Code compiles without warnings
- [x] `cargo clippy` passes with no warnings
- [x] Code is formatted (`cargo fmt`)
- [ ] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## Breaking Changes
None
