### PR TITLE
fix: default -F and --json to POST

### DIFF
--- a/packages/orb-cli/src/request.rs
+++ b/packages/orb-cli/src/request.rs
@@ -22,7 +22,7 @@ pub async fn build_request(builder: RequestBuilder, args: &Args, url: &Url) -> R
         method = m.0.clone();
     } else if args.head_only {
         method = Method::HEAD;
-    } else if args.data.is_some() {
+    } else if args.data.is_some() || args.json.is_some() || !args.form.is_empty() {
         method = Method::POST;
     }
 


### PR DESCRIPTION
## Summary
Fixes #36 

## Checklist
- [x] Code compiles without warnings
- [x] `cargo clippy` passes with no warnings
- [x] Code is formatted (`cargo fmt`)
- [ ] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## Breaking Changes
None
