### PR TITLE
fix: ensure consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Ensure consistent line endings across platforms
 * text=auto
+* text eol=lf
 
 # Test data files should preserve their line endings exactly
 packages/orb-cli/tests/testdata/*.txt text eol=lf


### PR DESCRIPTION
## Summary

Ensures consistent LF line endings. I was seeing line endings swap back and forth between CRLF and LF on Windows.