### PR TITLE
fix: prevent Authorization headers in redirects

### DIFF
--- a/docs/src/content/docs/cli/options-reference.mdx
+++ b/docs/src/content/docs/cli/options-reference.mdx
@@ -83,6 +83,7 @@ orb [OPTIONS] <URL>
 | `-m, --max-time <SECS>` | Maximum total request time in seconds |
 | `-L, --location` | Follow redirects |
 | `--max-redirs <NUM>` | Maximum redirects to follow. Default: 10 |
+| `--location-trusted` | Send Authorization header to different hosts on redirect |
 
 ## Network
 
@@ -301,6 +302,14 @@ Follow redirects:
 ```bash
 orb -L https://httpbin.org/redirect/3
 orb -L --max-redirs 5 https://example.com
+```
+
+### `--location-trusted`
+
+By default, the `Authorization` header is stripped when a redirect goes to a different host. Use `--location-trusted` to preserve it:
+
+```bash
+orb -L --location-trusted --bearer token https://auth.example.com/login
 ```
 
 ### `-x, --proxy`

--- a/docs/src/content/docs/cli/timeouts-redirects.mdx
+++ b/docs/src/content/docs/cli/timeouts-redirects.mdx
@@ -129,6 +129,27 @@ Orb follows these redirect status codes:
 Be careful with redirects when posting data. Some redirects may change the method or drop the body.
 </Aside>
 
+### Cross-Host Redirect Security
+
+When following redirects to a **different host**, orb automatically strips the `Authorization` header to prevent credential leakage.
+
+This protects against attacks where a malicious server redirects to a different host to steal credentials (see [CVE-2018-1000007](https://curl.se/docs/CVE-2018-1000007.html)).
+
+Redirects to the **same host** (same scheme, hostname, and port) preserve all headers.
+
+#### `--location-trusted`
+
+If you trust the redirect target and need to send credentials across hosts, use `--location-trusted`:
+
+```bash
+# Sends Authorization header even on cross-host redirects
+orb -L --location-trusted --bearer my-token https://auth.example.com/login
+```
+
+<Aside type="caution">
+Only use `--location-trusted` when you trust all servers in the redirect chain. Without it, your credentials are protected from being sent to unexpected hosts.
+</Aside>
+
 ### Redirect Loop Protection
 
 Orb detects redirect loops and stops:

--- a/packages/orb-cli/src/cli.rs
+++ b/packages/orb-cli/src/cli.rs
@@ -88,6 +88,14 @@ pub struct Args {
     #[arg(long = "max-redirs", value_name = "NUM", default_value = "10")]
     pub max_redirects: usize,
 
+    /// Send auth headers to hosts that differ from the original (on redirect)
+    ///
+    /// By default, the Authorization header is stripped when following redirects
+    /// to a different host. This flag preserves it regardless of the redirect
+    /// target.
+    #[arg(long = "location-trusted")]
+    pub location_trusted: bool,
+
     /// Connection timeout in seconds
     #[arg(long = "connect-timeout", value_name = "SECONDS", default_value = "10")]
     pub connect_timeout: u64,

--- a/packages/orb-cli/src/request.rs
+++ b/packages/orb-cli/src/request.rs
@@ -30,6 +30,7 @@ pub async fn build_request(builder: RequestBuilder, args: &Args, url: &Url) -> R
         .method(method)
         .follow_redirects(args.follow_redirects)
         .max_redirects(args.max_redirects)
+        .location_trusted(args.location_trusted)
         .connect_timeout(Duration::from_secs(args.connect_timeout))
         .insecure(args.insecure)
         .use_system_cert_store(true)

--- a/packages/orb-cli/tests/options.rs
+++ b/packages/orb-cli/tests/options.rs
@@ -2359,4 +2359,176 @@ fn test_progress_auto_start() {
     server.assert_requests(2);
 }
 
+/// Test that Authorization header is stripped on cross-host redirect
+#[test]
+fn test_redirect_strips_auth_cross_host() {
+    // Server A: redirects to Server B
+    let server_b = TestServerBuilder::new().build();
+    server_b.on_request_fn("/target", |req| {
+        let has_auth = req.header("authorization").is_some();
+        if has_auth {
+            ResponseBuilder::new()
+                .status(200)
+                .body("FAIL: Authorization header leaked")
+                .build()
+        } else {
+            ResponseBuilder::new()
+                .status(200)
+                .body("OK: no auth header")
+                .build()
+        }
+    });
+
+    let server_a = TestServerBuilder::new().build();
+    let redirect_target = server_b.url("/target");
+    server_a
+        .on_request("/start")
+        .respond_with_redirect(302, &redirect_target);
+
+    let mut cmd = Command::new(cargo_bin!("orb"));
+    cmd.arg(server_a.url("/start"))
+        .arg("--bearer")
+        .arg("secret-token")
+        .arg("-L");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "OK: no auth header");
+
+    server_a.assert_requests(1);
+    server_b.assert_requests(1);
+}
+
+/// Test that Authorization header is preserved on same-host redirect
+#[test]
+fn test_redirect_preserves_auth_same_host() {
+    let server = TestServerBuilder::new().build();
+    let final_url = server.url("/final");
+
+    server
+        .on_request("/start")
+        .respond_with_redirect(302, &final_url);
+    server.on_request_fn("/final", |req| {
+        let has_auth = req
+            .header("authorization")
+            .map(|v| v.contains("Bearer secret-token"))
+            .unwrap_or(false);
+        if has_auth {
+            ResponseBuilder::new()
+                .status(200)
+                .body("OK: auth preserved")
+                .build()
+        } else {
+            ResponseBuilder::new()
+                .status(200)
+                .body("FAIL: auth header missing")
+                .build()
+        }
+    });
+
+    let mut cmd = Command::new(cargo_bin!("orb"));
+    cmd.arg(server.url("/start"))
+        .arg("--bearer")
+        .arg("secret-token")
+        .arg("-L");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "OK: auth preserved");
+
+    server.assert_requests(2);
+}
+
+/// Test that --location-trusted preserves Authorization on cross-host redirect
+#[test]
+fn test_redirect_location_trusted() {
+    let server_b = TestServerBuilder::new().build();
+    server_b.on_request_fn("/target", |req| {
+        let has_auth = req
+            .header("authorization")
+            .map(|v| v.contains("Bearer secret-token"))
+            .unwrap_or(false);
+        if has_auth {
+            ResponseBuilder::new()
+                .status(200)
+                .body("OK: auth preserved with --location-trusted")
+                .build()
+        } else {
+            ResponseBuilder::new()
+                .status(200)
+                .body("FAIL: auth header missing")
+                .build()
+        }
+    });
+
+    let server_a = TestServerBuilder::new().build();
+    let redirect_target = server_b.url("/target");
+    server_a
+        .on_request("/start")
+        .respond_with_redirect(302, &redirect_target);
+
+    let mut cmd = Command::new(cargo_bin!("orb"));
+    cmd.arg(server_a.url("/start"))
+        .arg("--bearer")
+        .arg("secret-token")
+        .arg("-L")
+        .arg("--location-trusted");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "OK: auth preserved with --location-trusted");
+
+    server_a.assert_requests(1);
+    server_b.assert_requests(1);
+}
+
+/// Test that non-sensitive headers are preserved on cross-host redirect
+#[test]
+fn test_redirect_preserves_non_sensitive_headers_cross_host() {
+    let server_b = TestServerBuilder::new().build();
+    server_b.on_request_fn("/target", |req| {
+        let has_custom = req
+            .header("x-custom")
+            .map(|v| v == "keep-me")
+            .unwrap_or(false);
+        let has_auth = req.header("authorization").is_some();
+        if has_custom && !has_auth {
+            ResponseBuilder::new()
+                .status(200)
+                .body("OK: custom header preserved, auth stripped")
+                .build()
+        } else {
+            ResponseBuilder::new()
+                .status(200)
+                .body(format!("FAIL: custom={}, auth={}", has_custom, has_auth))
+                .build()
+        }
+    });
+
+    let server_a = TestServerBuilder::new().build();
+    let redirect_target = server_b.url("/target");
+    server_a
+        .on_request("/start")
+        .respond_with_redirect(302, &redirect_target);
+
+    let mut cmd = Command::new(cargo_bin!("orb"));
+    cmd.arg(server_a.url("/start"))
+        .arg("-H")
+        .arg("X-Custom: keep-me")
+        .arg("--bearer")
+        .arg("secret-token")
+        .arg("-L");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "OK: custom header preserved, auth stripped");
+
+    server_a.assert_requests(1);
+    server_b.assert_requests(1);
+}
+
 // fn test_ws_message

--- a/packages/orb-client/src/http_client.rs
+++ b/packages/orb-client/src/http_client.rs
@@ -291,10 +291,18 @@ impl HttpClient {
                 _ => (Method::GET, RequestBody::Empty),
             };
 
-            let mut req_builder = Request::builder().method(method).uri(new_uri);
+            let mut req_builder = Request::builder().method(method).uri(new_uri.clone());
+
+            // Determine headers for redirect request
+            let redirect_headers =
+                if !builder.location_trusted && is_cross_host(&current_uri, &new_uri) {
+                    strip_sensitive_headers(&builder.headers)
+                } else {
+                    builder.headers.clone()
+                };
 
             // Copy headers (except Host which hyper handles)
-            for (key, value) in builder.headers.iter() {
+            for (key, value) in redirect_headers.iter() {
                 if key != http::header::HOST {
                     req_builder = req_builder.header(key, value);
                 }
@@ -373,6 +381,7 @@ pub struct RequestBuilder {
     pub(crate) body: RequestBody,
     pub(crate) follow_redirects: bool,
     pub(crate) max_redirects: usize,
+    pub(crate) location_trusted: bool,
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) max_time: Option<Duration>,
     pub(crate) insecure: bool,
@@ -393,6 +402,7 @@ impl RequestBuilder {
             body: RequestBody::empty(),
             follow_redirects: false,
             max_redirects: 10,
+            location_trusted: false,
             connect_timeout: None,
             max_time: None,
             insecure: false,
@@ -446,6 +456,11 @@ impl RequestBuilder {
 
     pub fn max_redirects(mut self, max: usize) -> Self {
         self.max_redirects = max;
+        self
+    }
+
+    pub fn location_trusted(mut self, trusted: bool) -> Self {
+        self.location_trusted = trusted;
         self
     }
 
@@ -624,6 +639,41 @@ fn boxed_empty() -> BoxBody {
 
 fn boxed_full(bytes: Bytes) -> BoxBody {
     Full::new(bytes).map_err(|_| unreachable!()).boxed()
+}
+
+/// Check if two URIs point to different hosts (scheme + host + port)
+fn is_cross_host(original: &http::Uri, redirect: &http::Uri) -> bool {
+    let orig_scheme = original.scheme_str().unwrap_or("https");
+    let redir_scheme = redirect.scheme_str().unwrap_or("https");
+
+    if orig_scheme != redir_scheme {
+        return true;
+    }
+
+    let orig_host = original.host().unwrap_or("");
+    let redir_host = redirect.host().unwrap_or("");
+
+    if !orig_host.eq_ignore_ascii_case(redir_host) {
+        return true;
+    }
+
+    let default_port = if orig_scheme == "https" { 443 } else { 80 };
+    let orig_port = original.port_u16().unwrap_or(default_port);
+    let redir_port = redirect.port_u16().unwrap_or(default_port);
+
+    orig_port != redir_port
+}
+
+/// Clone headers but remove the Authorization header
+fn strip_sensitive_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut filtered = HeaderMap::new();
+    for (key, value) in headers.iter() {
+        if key == http::header::AUTHORIZATION {
+            continue;
+        }
+        filtered.append(key.clone(), value.clone());
+    }
+    filtered
 }
 
 /// Resolve a redirect Location header into an absolute URI


### PR DESCRIPTION
## Summary
Based on #39 - can be rebased once that's merged. Fixes in a similar way to curl at https://github.com/curl/curl/commit/af32cd3859336ab by adding `--location-trusted`

## Testing
<!-- How have you tested these changes? -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

## Checklist
- [x] Code compiles without warnings
- [x] `cargo clippy` passes with no warnings
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## Breaking Changes
- Technically, this is a breaking change for `-L` if anyone expected the `Authorization` header to be preserved across redirects. But in practice, I doubt this is functionality that anyone relies on.

## Related Issues
Fixes #40 
